### PR TITLE
Fix knitr 1.44 breakage by unlocking opts_current before modifyfing it 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: JuliaCall
 Type: Package
 Title: Seamless Integration Between R and 'Julia'
-Version: 0.17.5
+Version: 0.17.5.9000
 Date: 2022-09-08
 Authors@R: c(
     person("Changcheng", "Li", , "cxl508@psu.edu", c("aut", "cre")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# JuliaCall 0.17.5.9000
+
+* Fix breakage with **knitr** 1.44 when using Plots in a `julia` chunk ([#209](https://github.com/Non-Contradiction/JuliaCall/issues/209)).
+
 # JuliaCall 0.17.5
 
 * Nineteenth release on CRAN.

--- a/R/RMarkdown.R
+++ b/R/RMarkdown.R
@@ -55,7 +55,12 @@ begin_plot <- function(){
 
 ## This function is used by Julia plot_display function
 finish_plot <- function(){
+    ## FIXME: opts_current is supposed to be read-only
+    ## so it require unlock to be modified since knitr 1.44
+    ## https://yihui.org/en/2023/09/knitr-1-44/
+    knitr::opts_current$lock(FALSE)
     knitr::opts_current$set(Jfig.cur = .julia$pending_plot_number + 1L)
+    knitr::opts_current$lock(TRUE)
     julia$current_plot <- .julia$pending_plot
 }
 


### PR DESCRIPTION
This will solve #209 

As described in https://yihui.org/en/2023/09/knitr-1-44/ there is a change with `opts_current` that requires to unlock if modified for good reason, as the object is meant to be read-only

This PR does that. In general, there is other better ways to modify options in **knitr** and this should be targeted but this will solve current problems to update on CRAN. 

I did not added some tests because it would require Plots package and not sure how you handle Julia deps in there. 

The chunk that causes issue is : 
`````markdown
```{julia}
using Plots
plot(x->x)
```
`````
