### PR TITLE
Fix timeouts in install_julia

### DIFF
--- a/R/installJulia.R
+++ b/R/installJulia.R
@@ -93,7 +93,10 @@ install_julia <- function(version = "latest",
 
     file <- tempfile()
     tryCatch({
+        old_timeout = getOption("timeout")
+        options(timeout = 300)
         utils::download.file(url, file)
+        options(timeout = old_timeout)
     }, error = function(err) {
         stop(paste("There was an error downloading Julia. This could be due ",
                    "to network issues, and might be resolved by re-running ",


### PR DESCRIPTION
The current default timeout is too low for the current binary size so it tends to fail on v1.9. This makes it more robust.