### PR TITLE
Fix arch

### DIFF
--- a/R/installJulia.R
+++ b/R/installJulia.R
@@ -32,7 +32,7 @@ julia_url <- function(version){
     } else {
         "x86"
     }
-    short_version <- substr(version, 1, 3)
+    short_version <- paste(strsplit(version, "[.]")[[1]][1:2], collapse = ".")
     sysname <- Sys.info()["sysname"]
     if (sysname == "Linux") {
         os <- "linux"

--- a/R/installJulia.R
+++ b/R/installJulia.R
@@ -17,7 +17,9 @@ julia_latest_version <- function(){
     utils::download.file(url, file)
     versions <- rjson::fromJSON(file=file)
 
-    max(names(Filter(function(v) v$stable, versions)))
+    stable_versions <- names(Filter(function(v) v$stable, versions))
+    v <- as.numeric(gsub(".", "", stable_versions, fixed = TRUE))
+    return(stable_versions[v == max(v)])
 }
 
 

--- a/R/installJulia.R
+++ b/R/installJulia.R
@@ -23,7 +23,7 @@ julia_latest_version <- function(){
 
 julia_url <- function(version){
     sysmachine <- Sys.info()["machine"]
-    arch <- if (sysmachine == "arm64") {
+    arch <- if (sysmachine %in% c("arm64", "aarch64")) {
         "aarch64"
     } else if (.Machine$sizeof.pointer == 8) {
         "x64"


### PR DESCRIPTION
<!-- IF THIS INVOLVES AUTHENTICATION: DO NOT SHARE YOUR USERNAME/PASSWORD, OR API KEYS/TOKENS IN THIS ISSUE - MOST LIKELY THE MAINTAINER WILL HAVE THEIR OWN EQUIVALENT KEY -->

<!-- If you've updated a file in the man-roxygen directory, make sure to update the man/ files by running devtools::document() or similar as .Rd files should be affected by your change -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
JuliaCall cannot find the correct version of Julia on M-series Mac.

1. The command `Sys.info()["machine"]` returns `aarch64` on my M2 MacBook Air. This is not catered for in `julia_url()`;
2. `julia_latest_version()` returns the incorrect value since v1.10 as it uses string sorting to find the maximum version; and
3. `short_version` in `julia_url()` is set incorrectly since v1.10 since it only subsets the first 3 characters.

## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->

## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->

<!--- Did you remember to include tests? Unless you're just changing
grammar, please include new tests for your change -->
