### PR TITLE
Remove unused `jl_stdout_obj` import since it was removed in Julia 1.11

### DIFF
--- a/src/libjulia.cpp
+++ b/src/libjulia.cpp
@@ -131,7 +131,7 @@ bool load_libjulia_symbols() {
     LOAD_JULIA_SYMBOL(jl_stderr_stream);
     LOAD_JULIA_SYMBOL(jl_printf);
     // LOAD_JULIA_SYMBOL(jl_flush_cstdio);
-    LOAD_JULIA_SYMBOL(jl_stdout_obj);
+    // LOAD_JULIA_SYMBOL(jl_stdout_obj);
     LOAD_JULIA_SYMBOL(jl_stderr_obj);
 
     return true;

--- a/src/libjulia.h
+++ b/src/libjulia.h
@@ -120,7 +120,7 @@ JL_EXTERN int (*jl_printf)(uv_stream_t *s, const char *format, ...)
 
 // showing and std streams
 // L_EXTERN void (*jl_flush_cstdio)(void);
-JL_EXTERN jl_value_t* (*jl_stdout_obj)(void);
+// JL_EXTERN jl_value_t* (*jl_stdout_obj)(void);
 JL_EXTERN jl_value_t* (*jl_stderr_obj)(void);
 
 


### PR DESCRIPTION
This `jl_stdout_obj` doesn't seem to be used anywhere in the package, and was removed in Julia 1.11: https://github.com/JuliaLang/julia/pull/53250

Fixes #234 
